### PR TITLE
Feat/user store: Implement a generic user store

### DIFF
--- a/src/model/UserData.ts
+++ b/src/model/UserData.ts
@@ -1,0 +1,3 @@
+export interface UserData {
+  username: string;
+}

--- a/src/model/UserData.ts
+++ b/src/model/UserData.ts
@@ -1,3 +1,9 @@
 export interface UserData {
   username: string;
+  quizzes: {
+    [quizId: string]: boolean
+  },
+  achievements: {
+    [achievementId: string]: boolean
+  }
 }

--- a/src/model/UserData.ts
+++ b/src/model/UserData.ts
@@ -1,9 +1,9 @@
 export interface UserData {
   username: string;
   quizzes: {
-    [quizId: string]: boolean
-  },
+    [quizId: string]: boolean;
+  };
   achievements: {
-    [achievementId: string]: boolean
-  }
+    [achievementId: string]: boolean;
+  };
 }

--- a/src/services/user/LocalStorageUserStore.ts
+++ b/src/services/user/LocalStorageUserStore.ts
@@ -3,15 +3,41 @@ import { UserData } from "@/model/UserData";
 import Error from "next/error";
 
 export class LocalStorageUserStore implements UserStore {
+
+  private USER_STORE_KEY = "user"
+
+  private user: UserData | undefined = undefined
+
+  async loadUser(): Promise<UserData | null> {
+    const userString = window.localStorage.getItem(this.USER_STORE_KEY)
+    if(userString == null) {
+      return null
+    }
+
+    return JSON.parse(userString)
+  }
+
   async getUser(): Promise<UserData> {
-    return Promise.reject("Not implemented");
+    if(this.user == undefined) {
+      return Promise.reject("User not loaded.")
+    }
+    return this.user;
+  }
+
+  async saveUser(): Promise<boolean> {
+    window.localStorage.setItem(this.USER_STORE_KEY, JSON.stringify(this.user))
+    return true
   }
 
   async setQuizSolved(quizId: string, solved: boolean) {
-    return Promise.reject("Not implemented");
+    const user = await this.getUser()
+    user.quizzes[quizId] = solved
+    await this.saveUser()
   }
 
   async setAchievement(achievementId: string, unlocked: boolean) {
-    return Promise.reject("Not implemented");
+    const user = await this.getUser()
+    user.achievements[achievementId] = unlocked
+    await this.saveUser();
   }
 }

--- a/src/services/user/LocalStorageUserStore.ts
+++ b/src/services/user/LocalStorageUserStore.ts
@@ -1,0 +1,17 @@
+import { UserStore } from "@/services/user/UserStore";
+import { UserData } from "@/model/UserData";
+import Error from "next/error";
+
+export class LocalStorageUserStore implements UserStore {
+  async getUser(): Promise<UserData> {
+    return Promise.reject("Not implemented");
+  }
+
+  async setQuizSolved(quizId: string, solved: boolean) {
+    return Promise.reject("Not implemented");
+  }
+
+  async setAchievement(achievementId: string, unlocked: boolean) {
+    return Promise.reject("Not implemented");
+  }
+}

--- a/src/services/user/LocalStorageUserStore.ts
+++ b/src/services/user/LocalStorageUserStore.ts
@@ -3,41 +3,40 @@ import { UserData } from "@/model/UserData";
 import Error from "next/error";
 
 export class LocalStorageUserStore implements UserStore {
+  private USER_STORE_KEY = "user";
 
-  private USER_STORE_KEY = "user"
-
-  private user: UserData | undefined = undefined
+  private user: UserData | undefined = undefined;
 
   async loadUser(): Promise<UserData | null> {
-    const userString = window.localStorage.getItem(this.USER_STORE_KEY)
-    if(userString == null) {
-      return null
+    const userString = window.localStorage.getItem(this.USER_STORE_KEY);
+    if (userString == null) {
+      return null;
     }
 
-    return JSON.parse(userString)
+    return JSON.parse(userString);
   }
 
   async getUser(): Promise<UserData> {
-    if(this.user == undefined) {
-      return Promise.reject("User not loaded.")
+    if (this.user == undefined) {
+      return Promise.reject("User not loaded.");
     }
     return this.user;
   }
 
   async saveUser(): Promise<boolean> {
-    window.localStorage.setItem(this.USER_STORE_KEY, JSON.stringify(this.user))
-    return true
+    window.localStorage.setItem(this.USER_STORE_KEY, JSON.stringify(this.user));
+    return true;
   }
 
   async setQuizSolved(quizId: string, solved: boolean) {
-    const user = await this.getUser()
-    user.quizzes[quizId] = solved
-    await this.saveUser()
+    const user = await this.getUser();
+    user.quizzes[quizId] = solved;
+    await this.saveUser();
   }
 
   async setAchievement(achievementId: string, unlocked: boolean) {
-    const user = await this.getUser()
-    user.achievements[achievementId] = unlocked
+    const user = await this.getUser();
+    user.achievements[achievementId] = unlocked;
     await this.saveUser();
   }
 }

--- a/src/services/user/UserStore.ts
+++ b/src/services/user/UserStore.ts
@@ -7,7 +7,28 @@ export function getUserStore() {
 }
 
 export interface UserStore {
+  /**
+   * Loads the UserData object and caches it on the client.
+   * Can be null, if no user has been set up yet or no user could be loaded.
+   */
+  loadUser: () => Promise<UserData | null>
+
+  /**
+   * Returns the current user. Promise is rejected, if the user has not been
+   * loaded successfully. The returned object might not always hold the
+   * latest state.
+   * @return The user data
+   */
   getUser: () => Promise<UserData>;
+
+  /**
+   * Saves the user in the implemented user store.
+   * Depending on the implementation, saves might have to be performed manually after
+   * changing the user data.
+   * @return True, if the action was performed successfully.
+   */
+  saveUser: () => Promise<boolean>
+
   setQuizSolved: (quizId: string, solved: boolean) => Promise<void>;
   setAchievement: (achievementId: string, unlocked: boolean) => Promise<void>;
 }

--- a/src/services/user/UserStore.ts
+++ b/src/services/user/UserStore.ts
@@ -11,7 +11,7 @@ export interface UserStore {
    * Loads the UserData object and caches it on the client.
    * Can be null, if no user has been set up yet or no user could be loaded.
    */
-  loadUser: () => Promise<UserData | null>
+  loadUser: () => Promise<UserData | null>;
 
   /**
    * Returns the current user. Promise is rejected, if the user has not been
@@ -27,7 +27,7 @@ export interface UserStore {
    * changing the user data.
    * @return True, if the action was performed successfully.
    */
-  saveUser: () => Promise<boolean>
+  saveUser: () => Promise<boolean>;
 
   setQuizSolved: (quizId: string, solved: boolean) => Promise<void>;
   setAchievement: (achievementId: string, unlocked: boolean) => Promise<void>;

--- a/src/services/user/UserStore.ts
+++ b/src/services/user/UserStore.ts
@@ -1,0 +1,13 @@
+import { UserData } from "@/model/UserData";
+import { LocalStorageUserStore } from "@/services/user/LocalStorageUserStore";
+
+let userStore = new LocalStorageUserStore();
+export function getUserStore() {
+  return userStore;
+}
+
+export interface UserStore {
+  getUser: () => Promise<UserData>;
+  setQuizSolved: (quizId: string, solved: boolean) => Promise<void>;
+  setAchievement: (achievementId: string, unlocked: boolean) => Promise<void>;
+}


### PR DESCRIPTION
This PR adds a generic UserStore that should be used to save any kind of user data. The UserStore itself can be changed to enable different storing locations (on the client, on a remote database, ...)